### PR TITLE
Adapt cmake to build CY49T2 with ecbundle

### DIFF
--- a/src/programs/CMakeLists.txt
+++ b/src/programs/CMakeLists.txt
@@ -38,6 +38,7 @@ foreach( prec sp dp )
                              fiat
                              parkind_${prec}
                              trans_${prec}
+			   LINKER_LANGUAGE Fortran
                           )
   endif()
 endforeach()


### PR DESCRIPTION
This is a hotfix PR for an older version of ectrans. We are using the for_CY49T1 tag and we are working on a version that uses ecbundle already in 49T2 for a Destine collaboration with the limited area consortium. This fix was already merged into newer version of ectrans on the ecmwf-ifs repo (https://github.com/ecmwf-ifs/ectrans/commit/473775267fdeb93f9f5193e6a49d55c1558a3eee) but unfortunately, we have more problems with newer version of ectrans and rely on this tagged version. Would it be possible to merge this fix into the 1.2.0_forCY49T1 and if possible create a hotfix tag on top of for_CY49T1? 